### PR TITLE
feat: add .m4a file preview

### DIFF
--- a/app/utils/file.js
+++ b/app/utils/file.js
@@ -39,8 +39,8 @@ const SUPPORTED_DOCS_FORMAT = Platform.select({
 });
 
 const SUPPORTED_VIDEO_FORMAT = Platform.select({
-    ios: ['video/mp4', 'video/x-m4v', 'video/quicktime'],
-    android: ['video/3gpp', 'video/x-matroska', 'video/mp4', 'video/webm'],
+    ios: ['audio/mp4', 'video/mp4', 'video/x-m4v', 'video/quicktime'],
+    android: ['audio/mp4', 'video/3gpp', 'video/x-matroska', 'video/mp4', 'video/webm'],
 });
 
 const types = {};


### PR DESCRIPTION
This leverages the video player to play .m4a video files. m4a, mp4, m4v files use the same container format so they are all compatible in all players that support mp4 (just the extensions differ).

Since there is no video track, there is just a black space where the video is, and the audio track will play.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Enable .m4a audio file preview support in Mattermost Mobile, for Android and iOS by using the video player.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

iPhone XR, iOS 15.2.1
Google Nexus 6, Android 7.1.1

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
```release-note
Added .m4a audio file preview support via the video player.
```
